### PR TITLE
Fixed issues with specific suite names

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var SpecReporter = function (baseReporterDecorator) {
       }, this);
     }, this);
     Object.keys(failures.suites).forEach(function (suite) {
-      this.write((prefix + 'DESCRIBE => ' + suite + '\n').yellow);
+      this.write((prefix + 'DESCRIBE => ' + fromKey(suite) + '\n').yellow);
       this._logFinalErrors(failures.suites[suite], prefix + '  ');
     }, this);
   };
@@ -43,11 +43,22 @@ var SpecReporter = function (baseReporterDecorator) {
       var current = failures;
 
       result.suite.forEach(function (suite) {
-        current = current.suites[suite] = current.suites[suite] || {tests: [], suites: {}};
+        current = current.suites[toKey(suite)] = current.suites[toKey(suite)] || {tests: [], suites: {}};
       }, this);
       current.tests.push(result);
     }
   };
+
+  var KEY_PREFIX = '$$';
+
+  function toKey(forValue) {
+    return KEY_PREFIX + forValue;
+  }
+
+  function fromKey(forValue) {
+    return forValue.substring(KEY_PREFIX.length);
+  }
+
 };
 
 SpecReporter.$inject = ['baseReporterDecorator'];

--- a/test.js
+++ b/test.js
@@ -88,4 +88,18 @@ describe('Simple Reporter', function () {
     assert.equal(output, '\n');
   });
 
+  it('should not fail if suite name has reserved keywords', function () {
+    reporter.onSpecComplete('phantom', {suite: ['constructor'], description: 'd1', log: ['l1'], success: false});
+    reporter.onSpecComplete('phantom', {suite: ['toString'], description: 'd2', log: ['l2'], success: false});
+    reporter.onRunComplete(['phantom'], {failed: 2, success: 0});
+    assert.equal(output, '\n' + 'TOTAL: 2 FAILED'.red + ', ' + '0 SUCCESS'.green + '\n\n' +
+                 'DESCRIBE => constructor\n'.yellow +
+                 '  IT => d1\n'.cyan +
+                 '    ERROR => l1\n'.red +
+                 'DESCRIBE => toString\n'.yellow +
+                 '  IT => d2\n'.cyan +
+                 '    ERROR => l2\n'.red +
+                 '\n\n\n');
+  });
+
 });


### PR DESCRIPTION
There is a problem with suites having names like

```javascript
describe('constructor', function () {
  describe('toString', function () {
  });
});
```